### PR TITLE
Added quotes to allow for spaces in properties

### DIFF
--- a/macros/pivot_event_properties_json.sql
+++ b/macros/pivot_event_properties_json.sql
@@ -5,7 +5,7 @@
 replace(json_extract(event_properties, {{ "'$." ~ property ~ "'" }} ), '"', '') as {{ property }}
 
 {%- elif target.type == 'snowflake' -%}
-replace(parse_json(event_properties):{{ property }}, '"', '') as {{ property }}
+replace(parse_json(event_properties):"{{ property }}", '"', '') as "{{ property }}"
 
 {%- elif target.type == 'redshift' -%}
 replace(json_extract_path_text(event_properties, {{ "'" ~ property ~ "'" }} ), '"', '') as {{ property }}


### PR DESCRIPTION
This change is to fix an issue with the package where property names from Mixpanel may have spaces. Quoting the properties allows Snowflake to deal with spaces if they are present.

https://github.com/fivetran/dbt_mixpanel/issues/4