### PR TITLE
Add ability to pivot out event properties with spaces 

### DIFF
--- a/macros/pivot_event_properties_json.sql
+++ b/macros/pivot_event_properties_json.sql
@@ -2,14 +2,16 @@
 {% for property in list_of_properties -%}
 
 {%- if target.type == 'bigquery' -%}
-replace(json_extract(event_properties, {{ "'$." ~ property ~ "'" }} ), '"', '') as {{ property }}
+replace(json_extract(event_properties, {{ "'$." ~ property ~ "'" }} ), '"', '')
 
 {%- elif target.type == 'snowflake' -%}
-replace(parse_json(event_properties):{{ property }}, '"', '') as {{ property }}
+replace(parse_json(event_properties):"{{ property }}", '"', '')
 
 {%- elif target.type == 'redshift' -%}
-replace(json_extract_path_text(event_properties, {{ "'" ~ property ~ "'" }} ), '"', '') as {{ property }}
-{%- endif -%}
+replace(json_extract_path_text(event_properties, {{ "'" ~ property ~ "'" }} ), '"', '')
+{% endif -%}
+
+as {{ property | replace(' ', '_') | lower }}
 
 {%- if not loop.last -%},{%- endif %}
 {% endfor -%}


### PR DESCRIPTION
This builds off of this [PR](https://github.com/fivetran/dbt_mixpanel/pull/5) from @Abraflare.
- Fixes Snowflake parsing issue in which event properties with spaces (ie `'Operating System'`) were throwing errors when parsed from the property JSON
- For all warehouses, replaces spaces with underscores when pivoting out properties into column names.