### PR TITLE
Sessions partition

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'mixpanel'
-version: '0.4.0'
+version: '0.5.0'
 
 require-dbt-version: ">=0.20.0"
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -16,3 +16,4 @@ seeds:
     event:
       +column_types:
         time: timestamp
+        distinct_id: "{{ 'varchar(100)'  if target.type == 'redshift' else 'string'}}"

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -16,4 +16,5 @@ seeds:
     event:
       +column_types:
         time: timestamp
-        distinct_id: "{{ 'varchar(100)'  if target.type == 'redshift' else 'string'}}"
+        distinct_id: "{{ 'varchar(100)'  if target.type in ('redshift', 'postgres') else 'string'}}"
+        device_id: "{{ 'varchar(100)'  if target.type in ('redshift', 'postgres') else 'string'}}"

--- a/models/mixpanel.yml
+++ b/models/mixpanel.yml
@@ -296,6 +296,9 @@ models:
 
       - name: event_frequencies
         description: JSON of the frequency of each `event_type` during this user session.
+      
+      - name: user_id
+        dev_snowflake: Coalescing of `device_id` and `people_id`.
 
 macros:
   - name: analyze_funnel

--- a/models/mixpanel.yml
+++ b/models/mixpanel.yml
@@ -298,7 +298,7 @@ models:
         description: JSON of the frequency of each `event_type` during this user session.
       
       - name: user_id
-        dev_snowflake: Coalescing of `device_id` and `people_id`.
+        description: Coalescing of `device_id` and `people_id`.
 
 macros:
   - name: analyze_funnel

--- a/models/mixpanel__sessions.sql
+++ b/models/mixpanel__sessions.sql
@@ -80,7 +80,7 @@ session_numbers as (
 
     -- will cumulatively create session numbers
     sum(is_new_session) over (
-            partition by device_id
+            partition by device_id, date_day
             order by occurred_at asc
             rows between unbounded preceding and current row
             ) as session_number

--- a/models/mixpanel__sessions.sql
+++ b/models/mixpanel__sessions.sql
@@ -135,6 +135,7 @@ session_join as (
         session_ids.session_started_at,
         session_ids.session_started_on_day,
         session_ids.user_id, -- coalescing of device_id and peeople_id
+        session_ids.device_id,
         session_ids.total_number_of_events,
         agg_event_types.event_frequencies
 

--- a/models/mixpanel__sessions.sql
+++ b/models/mixpanel__sessions.sql
@@ -18,7 +18,8 @@ with events as (
         unique_event_id,
         people_id,
         date_day,
-        device_id
+        device_id,
+        coalesce(device_id, people_id) as user_id
 
         {% if var('session_passthrough_columns', []) != [] %}
         ,
@@ -33,9 +34,9 @@ with events as (
     {% if is_incremental() %}
 
     -- grab ALL events for each user to appropriately use window functions to sessionize
-    and device_id in (
+    and coalesce(device_id, people_id) in (
 
-        select distinct device_id
+        select distinct coalesce(device_id, people_id)
         from {{ ref('mixpanel__event') }}
 
         -- events can come in late and we want to still be able to incorporate them
@@ -57,7 +58,8 @@ previous_event as (
 
     select 
         *,
-        lag(occurred_at) over(partition by device_id order by occurred_at asc) as previous_event_at
+        -- limiting session-eligibility to same calendar day
+        lag(occurred_at) over(partition by user_id, date_day order by occurred_at asc) as previous_event_at
 
     from events 
 
@@ -67,7 +69,7 @@ new_sessions as (
     
     select 
         *,
-        -- had the previous session timed out?
+        -- had the previous session timed out? either via inactivity or a new calendar day occurring
         case when {{ dbt_utils.datediff('previous_event_at', 'occurred_at', 'minute') }} > {{ var('sessionization_inactivity', 30) }} or previous_event_at is null then 1
         else 0 end as is_new_session
 
@@ -80,7 +82,7 @@ session_numbers as (
 
     -- will cumulatively create session numbers
     sum(is_new_session) over (
-            partition by device_id, date_day
+            partition by user_id, date_day
             order by occurred_at asc
             rows between unbounded preceding and current row
             ) as session_number
@@ -92,13 +94,13 @@ session_ids as (
 
     select
         *,
-        min(occurred_at) over (partition by device_id, session_number) as session_started_at,
-        min(date_day) over (partition by device_id, session_number) as session_started_on_day,
+        min(occurred_at) over (partition by user_id, date_day, session_number) as session_started_at,
+        min(date_day) over (partition by user_id, date_day, session_number) as session_started_on_day,
 
-        {{ dbt_utils.surrogate_key(['device_id', 'session_number']) }} as session_id,
+        {{ dbt_utils.surrogate_key(['user_id', 'session_number', 'date_day']) }} as session_id,
 
-        count(unique_event_id) over (partition by device_id, session_number, event_type order by occurred_at rows between unbounded preceding and unbounded following) as number_of_this_event_type,
-        count(unique_event_id) over (partition by device_id, session_number order by occurred_at rows between unbounded preceding and unbounded following) as total_number_of_events
+        count(unique_event_id) over (partition by user_id, date_day, session_number, event_type order by occurred_at rows between unbounded preceding and unbounded following) as number_of_this_event_type,
+        count(unique_event_id) over (partition by user_id, date_day, session_number order by occurred_at rows between unbounded preceding and unbounded following) as total_number_of_events
 
 
     from session_numbers
@@ -132,7 +134,7 @@ session_join as (
         session_ids.people_id,
         session_ids.session_started_at,
         session_ids.session_started_on_day,
-        session_ids.device_id,
+        session_ids.user_id, -- coalescing of device_id and peeople_id
         session_ids.total_number_of_events,
         agg_event_types.event_frequencies
 

--- a/models/mixpanel__sessions.sql
+++ b/models/mixpanel__sessions.sql
@@ -69,7 +69,7 @@ new_sessions as (
     
     select 
         *,
-        -- had the previous session timed out? either via inactivity or a new calendar day occurring
+        -- had the previous session timed out? Either via inactivity or a new calendar day occurring
         case when {{ dbt_utils.datediff('previous_event_at', 'occurred_at', 'minute') }} > {{ var('sessionization_inactivity', 30) }} or previous_event_at is null then 1
         else 0 end as is_new_session
 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
no

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->
addresses the issue where BQ users were seeing `resources exceeded` errors by adding `date_day` as a partition clause in all of the window functions in the `sessions` model

also addresses the issue where some users may not have `device_id`'s, so we need to coalesce on `device_id` and `people_id` in order to sessionize

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [x] Yes (please provide breaking change details below.)
- [ ] No  (please provide explanation how the change is non breaking below.)

breaking bc sessionizing logic is changing for everyone

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [x] Yes, is the issue in zendesk?
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [x] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [ ] Other (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [x] BigQuery
- [x] Redshift
- [x] Snowflake
- [x] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🗻 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
