### PR TITLE
Hotfix/frequency variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ vars:
     mixpanel_database: your_database_name
     mixpanel_schema: your_schema_name 
 ```
-
 ### Pivoting Out Event Properties
 By default, this package selects the [default columns collected by Mixpanel](https://help.mixpanel.com/hc/en-us/articles/115004613766-What-properties-do-Mixpanel-s-libraries-store-by-default-). However, you likely have custom properties or columns that you'd like to include in the `mixpanel__event` model.
 
@@ -101,7 +100,14 @@ vars:
       - name:           "this_other_field"
         transform_sql:  "cast(this_other_field as string)"
 ```
-
+### Sessions Event Frequency Limit
+The `event_frequencies` field within the `mixpanel__sessions` model reports all event types and the frequency of those events as a JSON blob via a string aggregation. For some users there can be thousands of different event types that take place. For Redshift and Postgres warehouses there currently exists a limit for string aggregations (up to 65,535). As a result, in order for Redshift and Postgres users to still leverage the `event_frequencies` field, an artificial limit is applied to this field of 50,000. If you would like to adjust this limit, you may do so by modifying the below variable in your project configuration.
+```yml
+# dbt_project.yml
+vars:
+  mixpanel:
+    mixpanel__event_frequency_limit: 1000 ## Default is 50000
+```
 ### Event Date Range
 Because of the typical volume of event data, you may want to limit this package's models to work with a recent date range of your Mixpanel data (however, note that all final models are materialized as [incremental](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/materializations#incremental) tables).
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'mixpanel'
-version: '0.6.0'
+version: '0.6.1'
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 
@@ -15,6 +15,8 @@ models:
 vars:
   mixpanel:
     event_table: "{{ source('mixpanel', 'event') }}"
+
+    mixpanel__event_frequency_limit: 50000
 
     date_range_start: '2010-01-01'     # mostly global filter placed on mixpanel__event to limit the date range. does not apply to stg_mixpanel__event and stg_mixpanel__user_first_event
         # global_event_filter: # global filter to place on this whole package in order to remove noise from events

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'mixpanel_integration_tests'
-version: '0.4.0'
+version: '0.6.0'
 config-version: 2
 profile: 'integration_tests'
 

--- a/models/mixpanel__sessions.sql
+++ b/models/mixpanel__sessions.sql
@@ -110,9 +110,9 @@ session_ids as (
 agg_event_types as (
 
     select 
-        session_id,
+        session_id
         -- turn into json
-        '{' || {{ fivetran_utils.string_agg("(event_type || ': ' || number_of_events)", "', '") }} || '}' as event_frequencies
+        -- '{' || {{ fivetran_utils.string_agg("(event_type || ': ' || number_of_events)", "', '") }} || '}' as event_frequencies
     
     from (
 
@@ -136,8 +136,8 @@ session_join as (
         session_ids.session_started_on_day,
         session_ids.user_id, -- coalescing of device_id and peeople_id
         session_ids.device_id,
-        session_ids.total_number_of_events,
-        agg_event_types.event_frequencies
+        session_ids.total_number_of_events
+        -- agg_event_types.event_frequencies
 
         {% if var('session_passthrough_columns', []) != [] %}
         ,

--- a/models/mixpanel__sessions.sql
+++ b/models/mixpanel__sessions.sql
@@ -145,7 +145,7 @@ session_join as (
         {% endif %}
     
     from session_ids
-    join agg_event_types using(session_id) -- join regardless of event type
+    join agg_event_types using(session_id) -- join regardless of event type 
 
     where session_ids.is_new_session = 1 -- only return fields of first event
 

--- a/models/mixpanel__sessions.sql
+++ b/models/mixpanel__sessions.sql
@@ -111,8 +111,6 @@ agg_event_types as (
 
     select 
         session_id
-        -- turn into json
-        -- '{' || {{ fivetran_utils.string_agg("(event_type || ': ' || number_of_events)", "', '") }} || '}' as event_frequencies
     
     from (
 
@@ -137,7 +135,6 @@ session_join as (
         session_ids.user_id, -- coalescing of device_id and peeople_id
         session_ids.device_id,
         session_ids.total_number_of_events
-        -- agg_event_types.event_frequencies
 
         {% if var('session_passthrough_columns', []) != [] %}
         ,


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
Redshift and Postgres warehouses have a limit to the amount of aggregation that may take place within certain functions. The `mixpanel__sessions` model currently performs a LISTAGG and customers have identified the aggregation exceeds the limit. Therefore, a conditional was added to check if the target type is Redshift or Postgres. If it is either, it will only perform the aggregation if the count is less than the amount defined by the `mixpanel__event_frequency_limit` (default 50000) variable.

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide an explanation as to how the change is non-breaking below.)

This will more be an under the hood change that will not break for existing users. The limit is so large as well that I don't imagine any customers using this limit will not already have encountered an error before.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes, Issue/Feature #26 
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [ ] Local (please provide additional testing details below)

Tested this locally, but awaiting the customer to confirm the change worked on their end as well.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🔀 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
